### PR TITLE
Mariano orozco

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+logs_bcm.txt

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ from config.config import init_db, db, init_jwt, init_cors
 from config.config_mp import init_mp
 from routes import init_app
 from utils.bot import enviar_alerta
-
+from config.config_mail import init_mail
 app = Flask(__name__)
 # CORS(app, supports_credentials=True)
 
@@ -17,7 +17,7 @@ init_mp()
 init_db(app)
 init_jwt(app)
 init_cors(app) # En caso de entrar en modo desarrollador comentar y volver al comando basico de cors
-
+init_mail(app)
 
 # Crea las tablas en la base de datos
 with app.app_context():

--- a/config/config_mail.py
+++ b/config/config_mail.py
@@ -1,0 +1,18 @@
+from flask_mail import Mail
+import os
+
+mail = Mail()
+
+def init_mail(app):
+    app.config['MAIL_SERVER'] = os.getenv('MAIL_SERVER', 'smtp.donweb.com')
+    app.config['MAIL_PORT'] = int(os.getenv('MAIL_PORT', 587))
+    app.config['MAIL_USE_TLS'] = os.getenv('MAIL_USE_TLS', 'true').lower() == 'true'
+    app.config['MAIL_USE_SSL'] = os.getenv('MAIL_USE_SSL', 'false').lower() == 'true'
+    app.config['MAIL_USERNAME'] = os.getenv('MAIL_USERNAME')
+    app.config['MAIL_PASSWORD'] = os.getenv('MAIL_PASSWORD')
+    app.config['MAIL_DEFAULT_SENDER'] = (
+        os.getenv('MAIL_DEFAULT_SENDER_NAME', 'Colejus'),
+        os.getenv('MAIL_DEFAULT_SENDER_EMAIL', os.getenv('MAIL_USERNAME'))
+    )
+
+    mail.init_app(app)

--- a/models/derecho_fijo.py
+++ b/models/derecho_fijo.py
@@ -18,6 +18,7 @@ class DerechoFijoModel(db.Model):
     parte = db.Column(db.String(255), nullable=True)
     juzgado = db.Column(db.String(255), nullable=True)
     total_depositado = db.Column(db.String(80), nullable=True)
+    email = db.Column(db.String(100), nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     
     def __repr__(self):
@@ -37,6 +38,7 @@ class DerechoFijoModel(db.Model):
             'parte': self.parte,
             'juzgado': self.juzgado,
             'total_depositado': self.total_depositado,
+            "email": self.email,
             'created': self.created_at.isoformat() if self.created_at else None
         }
 
@@ -64,6 +66,7 @@ class DerechoFijoModel(db.Model):
         derecho_fijo.caratula = json_dict['caratula']
         derecho_fijo.parte = json_dict['parte']
         derecho_fijo.juzgado = json_dict['juzgado']
+        derecho_fijo.email = json_dict['email']
         derecho_fijo.total_depositado = json_dict['total_depositado']
         
         return derecho_fijo

--- a/routes/forms.py
+++ b/routes/forms.py
@@ -4,6 +4,7 @@ from sqlalchemy import and_, or_
 from config.config import db
 from models import DerechoFijoModel, RateModel, ReceiptModel, PriceDerechoFijo
 from utils.decorators import token_required, access_required
+from utils.send_mails import enviar_comprobante_pago_por_mail
 from flask_jwt_extended import jwt_required
 from utils.errors import ValidationError, register_in_txt
 from config.config_mp import get_mp_sdk
@@ -198,11 +199,6 @@ def obtencion_codigo_qr(preference_data: dict, api_key: str, secret: str) -> dic
     except Exception:
         err = {"text": resp.text}
     raise ValueError(f"BCM: respuesta inesperada {resp.status_code}: {err}")
-
-    
-
-
-
 
 @forms_bp.route('/forms/derecho_fijo_qr_bcm', methods=['POST'])
 def generar_qr_bcm():
@@ -499,7 +495,7 @@ def derecho_fijo_tarjeta():
         return jsonify({"error": str(e)}), 500
 
 
-
+## Ralizamos las importaciones de los modulos de envio de mail
 
 @forms_bp.route('/forms/webhook', methods=['POST'])
 def handle_webhook():
@@ -559,6 +555,10 @@ def handle_webhook():
                               "payment_method:", payment_method)
                         
                         save_receipt_to_db(db.session, derecho_fijo, payment_id, status="Pagado", payment_method=payment_method)
+
+                        # Envio de correo con confirmacion de pago
+                        enviar_comprobante_pago_por_mail(derecho_fijo.uuid, payment_method, payment_id)
+                        
                         print("✅ Recibo guardado correctamente.")
 
                     else:
@@ -680,16 +680,25 @@ def bcm_webhook_oficial():
                     receipt.fecha_pago = datetime.utcnow()
                     db.session.add(receipt)
                     db.session.commit()
-                    print(f"✅ Recibo {receipt.uuid} marcado como Pagado por BCM.")
+                    print(f"✅ Recibo {cod_cliente} marcado como Pagado por BCM.")
 
-                print(f"ℹ️ Recibo {receipt.uuid} ya estaba Pagado, no se actualiza.")
+                    ## Envio de mails
+                    enviar_comprobante_pago_por_mail(receipt.uuid_derecho_fijo, receipt.payment_method, cod_cliente)
+
+                    return jsonify({"ok": True}), 200
+
+
+                # si ya estaba Pagado, no se actualiza
+
+                print(f"ℹ️ Recibo {cod_cliente} ya estaba Pagado, no se actualiza.")
+                enviar_comprobante_pago_por_mail(receipt.uuid_derecho_fijo, receipt.payment_method, cod_cliente)
                 return jsonify({"ok": True}), 200
 
             else:
-                print(f"ℹ️ Recibo {receipt.uuid} no actualizado, estado BCM: {estado_transaccion}")
+                print(f"ℹ️ Recibo {cod_cliente} no actualizado, estado BCM: {estado_transaccion}")
                 return jsonify({"ok": False, "error": "El recibo no se pudo actualizar. El status enviado no coincide con los siguientes (pagado, aprobado, approved)"}), 409
         else:
-            print(f"❌ No se encontró recibo para DerechoFijo {df.uuid} (juicio_n={df.juicio_n})")
+            print(f"❌ No se encontró recibo para payment_id {9321747794} (juicio_n={df.juicio_n})")
             return jsonify({"ok": False, "error": "No se encontró recibo para el DerechoFijo asociado."}), 404
 
                 # si vino “fallido”, podrías guardar “Rechazado”/“Fallido” (opcional)
@@ -698,6 +707,7 @@ def bcm_webhook_oficial():
 
     except Exception as e:
         print("❌ Error en bcm_webhook_oficial:", e)
+        traceback.print_exc()
         register_in_txt(f"Error en bcm_webhook_oficial: {e}", "logs_bcm.txt")
         enviar_alerta(f"❌ Error en bcm_webhook_oficial: {e}")
         return jsonify({"ok": "False",

--- a/utils/send_mails.py
+++ b/utils/send_mails.py
@@ -1,0 +1,59 @@
+from flask_mail import Message
+from config.config_mail import mail
+from models import DerechoFijoModel
+from flask import jsonify
+import os
+
+
+def enviar_mail(destinatario: str, asunto: str, html: str, adjuntos: list = None):
+    msg = Message(asunto, recipients=[destinatario])
+    msg.html = html
+    # adjuntos = [(filename, mimetype, bytes_content), ...]
+    for adj in adjuntos or []:
+        filename, mimetype, content = adj
+        msg.attach(filename=filename, content_type=mimetype, data=content)
+    mail.send(msg)
+
+
+
+def enviar_comprobante_pago_por_mail(uuid_derecho_fijo, payment_method, payment_id):
+    try:
+
+        # Destinatario (por ahora fijo o tomado del form si lo mandás)
+        derecho_fijo = DerechoFijoModel.query.filter_by(uuid=uuid_derecho_fijo).first()
+
+        if not derecho_fijo:
+            return jsonify({"error al enviar mail": "Formulario no encontrado"}), 404
+        
+        destinatario = derecho_fijo.email
+    
+        # Link directo para descargar el comprobante (usa el backend actual)
+        backend_url = os.environ.get('BACKEND_URL', 'http://localhost:5000')
+        download_link = f"{backend_url}/api/forms/download_receipt?derecho_fijo_uuid={derecho_fijo.uuid}"
+        # Asunto
+        asunto = f"Pago registrado para el Derecho Fijo del expediente {derecho_fijo.juicio_n}"
+
+        
+        html = f"""
+        <div style="font-family:Arial,Helvetica,sans-serif; color:#222;">
+        <h2>Pago registrado</h2>
+        <p>Se registró el pago del Derecho Fijo del expediente <b>{derecho_fijo.juicio_n}</b>.</p>
+        <ul>
+            <li>Carátula: {derecho_fijo.caratula or '-'}</li>
+            <li>Juzgado: {derecho_fijo.juzgado or '-'}</li>
+            <li>Total depositado: <b>${derecho_fijo.total_depositado}</b></li>
+            <li>Método: {payment_method}</li>
+            <li>ID de pago: {payment_id}</li>
+        </ul>
+        <p>Podés descargar el comprobante desde este enlace:</p>
+        <p><a href="{download_link}" target="_blank">{download_link}</a></p>
+        <hr/>
+        <p style="font-size:12px;color:#666;">Colegio Público de Abogados y Procuradores – Segunda Circunscripción (Mendoza)</p>
+        </div>
+        """
+
+        enviar_mail(destinatario, asunto, html)
+    
+    except Exception as ex:
+        print("⚠️ Error preparando el correo", ex)
+        return None


### PR DESCRIPTION
Se aplican las modificaciones necesarias para realizar el envio de mails cuando se aprueben los pagos aprobados tanto por la Bolsa de Comercio, como de Mercado pago. Se crearon 2 funciones que se llaman "enviar_mail" y otra que se llama "enviar_comprobante_de_pago", Ambas funciones se encuentran en utils/send_mail.py con el fin de mantener la modularizacion del proyecto y que sea mas facil depurar. 

Actualmente no esta en funcionamiento ya que no contamos con un correo de domino que nos provea un SMTP para el envió de mails. Cuando se obtenga dicho domino, configurar las variables de entorno y probar