### PR TITLE
feat: Solución de restricciones

### DIFF
--- a/services/membership_sync_service.py
+++ b/services/membership_sync_service.py
@@ -311,6 +311,7 @@ class MembershipSyncService:
 
         provisioned = 0
 
+        # First pass: create all missing users and add lawyer profiles
         for status_record in statuses:
             if status_record.status == MEMBERSHIP_STATUS_AMBIGUOUS:
                 continue
@@ -339,18 +340,28 @@ class MembershipSyncService:
             elif lawyer_profile not in user.profiles:
                 user.profiles.append(lawyer_profile)
 
-            status_record.uuid_user = user.uuid
+        # Flush to database so all user uuids are created and exist in the users table
+        db.session.flush()
 
-            professional = prof_by_tuition.get(tuition)
+        # Second pass: link status records and professionals to the users
+        for status_record in statuses:
+            if status_record.status == MEMBERSHIP_STATUS_AMBIGUOUS:
+                continue
 
-            if professional:
-                if not professional.uuid_user:
-                    professional.uuid_user = user.uuid
-                status_record.uuid_professional = professional.uuid
-                db.session.add(professional)
+            tuition = status_record.tuition_normalized
+            user = users_by_email.get(tuition.lower())
+            if not user and status_record.tuition_display:
+                user = users_by_email.get(status_record.tuition_display.lower())
 
-            db.session.add(status_record)
-            db.session.add(user)
+            if user:
+                status_record.uuid_user = user.uuid
+                professional = prof_by_tuition.get(tuition)
+                if professional:
+                    if not professional.uuid_user:
+                        professional.uuid_user = user.uuid
+                    status_record.uuid_professional = professional.uuid
+                    db.session.add(professional)
+                db.session.add(status_record)
 
         db.session.commit()
         return provisioned


### PR DESCRIPTION
membership_sync_service.py
 (se ajustó el método _provision_lawyer_users para procesar el guardado de datos en dos pasos, evitando un fallo de clave foránea al actualizar la tabla de profesionales).

## 📝 Descripción

Describe detalladamente los cambios introducidos por este Pull Request, el problema que resuelven y el contexto de la implementación.

---

## 🛠️ Tipo de Cambio

- [x] Nueva funcionalidad (`feat`)
- [ ] Corrección de errores (`fix`)
- [ ] Refactorización de código (`refactor`)
- [ ] Optimización de rendimiento (`perf`)
- [ ] Documentación (`docs`)
- [ ] Tareas de mantenimiento o configuración (`chore`)

---

## 🔗 Tickets o Issues Asociados

- Asocia el issue o ticket correspondiente (ej. `Fixes #123`, `Closes #456`).

---

## 🗄️ ¿Requiere Cambios en Base de Datos?

- [ ] **No** requiere cambios.
- [ ] **Sí** requiere cambios.
  - [ ] ¿Se generó el script de migración con `flask db migrate`?
  - [ ] ¿El script fue probado localmente con `flask db upgrade` y `flask db downgrade`?
  - [ ] ¿Se actualizó el modelo correspondiente en la carpeta `models/`?

---

## 🧪 ¿Cómo se probó?

Describe las pruebas realizadas para comprobar el correcto funcionamiento del cambio:
- **Pruebas automatizadas:** (ej. `pytest tests/test_rate_limit.py`)
- **Pruebas manuales/endpoints:** (ej. Petición POST a `/api/rooms/upload-image` mediante Postman con un archivo PNG de 1MB)

---

## 📋 Lista de Verificación (Checklist)

- [ ] Mi código sigue las guías de estilo del proyecto (nombres de tablas/columnas estrictamente en minúsculas y snake_case).
- [ ] He realizado una auto-revisión de mi propio código.
- [ ] He agregado comentarios en partes complejas del código.
- [ ] He actualizado la documentación correspondiente (archivos `README.md` locales si aplica).
- [ ] Mis cambios no introducen nuevas advertencias o errores de consola.
- [ ] Todas las pruebas de la suite de testing p6asan correctamente (`pytest`).
- [ ] Las variables de entorno necesarias han sido documentadas y/o cargadas en el archivo `.env.example`.
